### PR TITLE
Added ZF3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $records = array(
 	),
 );
 
-return $this->csvExport('foo.csv', $header, $records);
+return $this->CsvExport('foo.csv', $header, $records);
 ~~~
 
 The plugin will return a response object which you can then return from your controller action.
@@ -66,7 +66,7 @@ Import data from a CSV file using this plugin.
 ~~~php
 // inside a controller action
 
-$csv = $this->csvImport('/path/to/foo.csv');
+$csv = $this->CsvImport('/path/to/foo.csv');
 
 foreach ($csv as $row)
 {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"zendframework/zend-http": "2.*",
-		"zendframework/zend-mvc": "2.*"
+		"zendframework/zend-mvc": "2.* || 3.*"
 	},
 	"require-dev": {
 		"mikey179/vfsStream": "*",


### PR DESCRIPTION
Added needed changes to support ZF3 as well as ZF2. A new release should be created. This does not break backward compatibility, but enables folks to use ZF3.

However, those upgrading to ZF3 will need to also update their old calls to this plugin due to case sensitivity. (if they used the old documentation of this plugin that used lower case first letter)