### PR TITLE
Migrate to Laminas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ php:
   - "7.2"
   - "7.1"
   - "7.0"
+  - "5.6"
 install:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 php:
+  - "7.4"
+  - "7.3"
+  - "7.2"
   - "7.1"
   - "7.0"
-  - "5.6"
-  - "5.5"
 install:
   - composer install

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RdnCsv
 ======
 
-The **RdnCsv** ZF2 and ZF3 module makes it really easy to export and import CSV files.
+The **RdnCsv** Laminas module makes it really easy to export and import CSV files.
 
 ## How to install
 

--- a/composer.json
+++ b/composer.json
@@ -1,25 +1,31 @@
 {
-	"name": "radnan/rdn-csv",
-	"description": "Zend Framework 2/3 module to export and import CSV files",
-	"keywords": ["zf2", "zf3", "zendframework", "zend", "csv", "export", "import"],
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "radnan",
-			"email": "rafiadnan47@gmail.com"
-		}
-	],
-	"require": {
-		"zendframework/zend-http": "^2.6",
-		"zendframework/zend-mvc": "^2.7.9 || ^3.1"
-	},
-	"require-dev": {
-		"mikey179/vfsStream": "*",
-		"phpunit/phpunit": "3.*"
-	},
-	"autoload": {
-		"psr-0": {
-			"RdnCsv\\": "src/"
-		}
-	}
+    "name": "radnan/rdn-csv",
+    "description": "Laminas module to export and import CSV files",
+    "keywords": [
+        "csv",
+        "export",
+        "import",
+        "laminas"
+    ],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "radnan",
+            "email": "rafiadnan47@gmail.com"
+        }
+    ],
+    "require": {
+        "laminas/laminas-http": "^2.6",
+        "laminas/laminas-mvc": "^2.7.9 || ^3.1",
+        "laminas/laminas-dependency-plugin": "^1.0"
+    },
+    "require-dev": {
+        "mikey179/vfsStream": "*",
+        "phpunit/phpunit": "3.*"
+    },
+    "autoload": {
+        "psr-0": {
+            "RdnCsv\\": "src/"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "laminas/laminas-dependency-plugin": "^1.0"
     },
     "require-dev": {
-        "mikey179/vfsStream": "*",
-        "phpunit/phpunit": "3.*"
+        "mikey179/vfsstream": "*",
+        "phpunit/phpunit": "^7.5"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     ],
     "require": {
         "laminas/laminas-http": "^2.6",
-        "laminas/laminas-mvc": "^2.7.9 || ^3.1",
-        "laminas/laminas-dependency-plugin": "^1.0"
+        "laminas/laminas-mvc": "^2.7.9 || ^3.1"
     },
     "require-dev": {
         "mikey179/vfsstream": "*",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "*",
-        "phpunit/phpunit": "^6.5 || ^7.5"
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "*",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^6.5 || ^7.5"
     },
     "autoload": {
         "psr-0": {

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,7 +1,7 @@
 <?php
 
 use RdnCsv\Controller\Plugin;
-use Zend\ServiceManager\Factory\InvokableFactory;
+use Laminas\ServiceManager\Factory\InvokableFactory;
 
 return array(
 	'controller_plugins' => array(

--- a/src/RdnCsv/Controller/Plugin/CsvExport.php
+++ b/src/RdnCsv/Controller/Plugin/CsvExport.php
@@ -2,8 +2,8 @@
 
 namespace RdnCsv\Controller\Plugin;
 
-use Zend\Http\PhpEnvironment\Response as HttpResponse;
-use Zend\Mvc\Controller\Plugin\AbstractPlugin;
+use Laminas\Http\PhpEnvironment\Response as HttpResponse;
+use Laminas\Mvc\Controller\Plugin\AbstractPlugin;
 
 /**
  * Easily export data to downloadable CSV files.

--- a/src/RdnCsv/Controller/Plugin/CsvImport.php
+++ b/src/RdnCsv/Controller/Plugin/CsvImport.php
@@ -3,7 +3,7 @@
 namespace RdnCsv\Controller\Plugin;
 
 use SplFileObject;
-use Zend\Mvc\Controller\Plugin\AbstractPlugin;
+use Laminas\Mvc\Controller\Plugin\AbstractPlugin;
 
 /**
  * Quickly import CSV files and iterate over each record.

--- a/tests/RdnCsv/Controller/Plugin/CsvExportTest.php
+++ b/tests/RdnCsv/Controller/Plugin/CsvExportTest.php
@@ -6,7 +6,7 @@ use org\bovigo\vfs\vfsStream;
 use Laminas\Mvc\Controller\PluginManager;
 use Laminas\ServiceManager\ServiceManager;
 
-class CsvExportTest extends \PHPUnit_Framework_TestCase
+class CsvExportTest extends \PHPUnit\Framework\TestCase
 {
 	private $vfs;
 

--- a/tests/RdnCsv/Controller/Plugin/CsvExportTest.php
+++ b/tests/RdnCsv/Controller/Plugin/CsvExportTest.php
@@ -3,8 +3,8 @@
 namespace RdnCsv\Controller\Plugin;
 
 use org\bovigo\vfs\vfsStream;
-use Zend\Mvc\Controller\PluginManager;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\Mvc\Controller\PluginManager;
+use Laminas\ServiceManager\ServiceManager;
 
 class CsvExportTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/RdnCsv/Controller/Plugin/CsvImportTest.php
+++ b/tests/RdnCsv/Controller/Plugin/CsvImportTest.php
@@ -6,7 +6,7 @@ use org\bovigo\vfs\vfsStream;
 use Laminas\Mvc\Controller\PluginManager;
 use Laminas\ServiceManager\ServiceManager;
 
-class CsvImportTest extends \PHPUnit_Framework_TestCase
+class CsvImportTest extends \PHPUnit\Framework\TestCase
 {
 	private $vfs;
 

--- a/tests/RdnCsv/Controller/Plugin/CsvImportTest.php
+++ b/tests/RdnCsv/Controller/Plugin/CsvImportTest.php
@@ -3,8 +3,8 @@
 namespace RdnCsv\Controller\Plugin;
 
 use org\bovigo\vfs\vfsStream;
-use Zend\Mvc\Controller\PluginManager;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\Mvc\Controller\PluginManager;
+use Laminas\ServiceManager\ServiceManager;
 
 class CsvImportTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This PR migrates this module to Laminas using the laminas migration tool (and then some hand-editing to get travis tests to pass).

This probably warrants a major version bump of the module.

PHP 5.5 was removed from the travis matrix because it's not supported on travis any longer.